### PR TITLE
POC for converting IOL interface responses

### DIFF
--- a/node.go
+++ b/node.go
@@ -155,6 +155,20 @@ func (s *NodeService) GetNodeInterfaces(path string, node int) (*Interfaces, err
 	if err != nil {
 		return nil, err
 	}
+	// some nodes have ethernet as map[string]interface{} instead of []interface{}, namely the IOL nodes
+	// check if type of eve.Data.(map[string]interface{})["ethernet"] is []interface{} or map[string]interface{}
+	// if it is map[string]interface{} then convert it to []interface{}, else leave it as is
+	ethernet := eve.Data.(map[string]interface{})["ethernet"]
+	if _, ok := ethernet.(map[string]interface{}); ok {
+		var eths []Interface
+		for _, v := range ethernet.(map[string]interface{}) {
+			eths = append(eths, Interface{
+				Name:      v.(map[string]interface{})["name"].(string),
+				NetworkId: int(v.(map[string]interface{})["network_id"].(float64)),
+			})
+		}
+		eve.Data.(map[string]interface{})["ethernet"] = eths
+	}
 	data, err := json.Marshal(eve.Data)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
This is definitely not the way to do this, but I am not particularly go savvy, and this was my first stab at adding this. I am guessing the better way to go about this is to create a custom UnmarshalJSON to handle these.

Presently, the `GetNodeInterfaces` function is failing with IOL nodes. Here is the output comparing the responses from EVE-NG for given nodes of types `qemu` and `iol` respectively:

* qemu (vpcs)
```
{
  "ethernet": [
    {
      "name": "eth0",
      "network_id": 0
    }
  ],
  "id": 1,
  "serial": [],
  "sort": "vpcs"
}
```

* iol
```
{
  "ethernet": {
    "0": {
      "name": "e0/0",
      "network_id": 0
    },
    "16": {
      "name": "e0/1",
      "network_id": 0
    },
    "32": {
      "name": "e0/2",
      "network_id": 0
    },
    "48": {
      "name": "e0/3",
      "network_id": 0
    }
  },
  "id": 1,
  "serial": [],
  "sort": "iol"
}
```

All this does is change it from a map to a slice. It does drop the key, but given that the key seems to be useless anyway, I don't see that as a problem. Would love feedback on this, thanks!